### PR TITLE
allow for arrays of matchable values in a where call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crorm",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Catch&Release ORM",
   "main": "dist/orm.js",
   "scripts": {

--- a/src/orm/ormSelectors.js
+++ b/src/orm/ormSelectors.js
@@ -38,8 +38,13 @@ export const selectEntitiesWhere = createSelector([getProps, getEntityType, getE
       Object.keys(propsWithoutEntityType).every(prop => {
         const key = prop;
         const value = props[prop] === 'id' ? props[prop].toString() : props[prop];
+        const entityValue = entity.getIn([key], '');
 
-        return entity.getIn([key], '') === value;
+        if (Array.isArray(value)) {
+          return value.includes(entityValue);
+        }
+
+        return entityValue === value;
       }), null, Immutable.Map())
   };
 });

--- a/test/ormBase.test.js
+++ b/test/ormBase.test.js
@@ -282,20 +282,42 @@ describe('ORMBase', () => {
         describe('results', () => {
           let results;
 
-          beforeEach(() => {
-            results = Shot.where({ projectId: '1' });
+          describe('single match value', () => {
+            beforeEach(() => {
+              results = Shot.where({ projectId: '1' });
+            });
+
+            test('returns an Immutable List', () => {
+              expect(results).toBeInstanceOf(Immutable.List);
+            });
+
+            test('array contains all results', () => {
+              expect(results.count()).toBe(2);
+              expect(results.every((result) => result.projectId === '1')).toBe(true);
+            });
+
+            test('array items are Shots', () => {
+              expect(results.first()).toBeInstanceOf(Shot);
+            });
           });
 
-          test('returns an Immutable List', () => {
-            expect(results).toBeInstanceOf(Immutable.List);
-          });
+          describe('array of matchable values', () => {
+            beforeEach(() => {
+              results = Shot.where({ projectId: ['1', '2'] });
+            });
 
-          test('array containts all results', () => {
-            expect(results.count()).toBe(2);
-          });
+            test('returns an Immutable List', () => {
+              expect(results).toBeInstanceOf(Immutable.List);
+            });
 
-          test('array items are Shots', () => {
-            expect(results.first()).toBeInstanceOf(Shot);
+            test('array contains all results', () => {
+              expect(results.count()).toBe(3);
+              expect(results.every((result) => ['1', '2'].includes(result.projectId))).toBe(true);
+            });
+
+            test('array items are Shots', () => {
+              expect(results.first()).toBeInstanceOf(Shot);
+            });
           });
         });
 


### PR DESCRIPTION
i.e. now you can `Asset.where({ entityId: ['1', '2', '3'] })`