### PR TITLE
Fix memoization

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,9 @@ To Add Debug Output: `ORM.Config.debug = true;`
 
 `order()` - Get an Immutable List of ids containing the server ordering for the current entityType.
 
-`order(true)` - Get an Immutable of the ordering for the current entityType in { entityOrder: Immutable.List } format.
-
-`ordered()` - Get an Immutable List of ordered instances for the current entityType.
+`ordered(props = {})` - Get an Immutable List of ordered instances for the current entityType.
 
 `pagination()` - Get the pagination for the current entityType. 
-
-`pagination(true)` - Get an Immutable of the pagination for the current entityType in { pagination: Immutable.Map } format.
 
 `findById(id)` - Get the instance matching the id for the entityType. Returns instance with empty Immutable.Map() when not found.
 

--- a/dist/orm/ormSelectors.js
+++ b/dist/orm/ormSelectors.js
@@ -3,21 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.selectPagination = exports.selectOrderedEntities = exports.selectEntityOrder = exports.selectEntitiesWhere = exports.selectEntities = exports.selectEntity = exports.getEntityOrder = undefined;
+exports.createPaginationSelector = exports.createOrderedEntitiesSelector = exports.createEntityOrderSelector = exports.createWhereSelector = exports.createEntitiesSelector = exports.createEntitySelector = undefined;
 
 var _immutable = require('immutable');
 
 var _immutable2 = _interopRequireDefault(_immutable);
 
-var _pluralize = require('pluralize');
-
-var _pluralize2 = _interopRequireDefault(_pluralize);
-
 var _reselect = require('reselect');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var getProps = function getProps(state, props) {
   return props;
@@ -25,66 +19,88 @@ var getProps = function getProps(state, props) {
 var getId = function getId(state, props) {
   return props.id;
 };
-var getEntityType = function getEntityType(state, props) {
-  return props.entityType;
-};
-var getPagination = function getPagination(state, props) {
-  return state.data.getIn(['pagination', props.entityType], _immutable2.default.Map()) || _immutable2.default.Map();
-};
-var getEntities = function getEntities(state, props) {
-  return state.data.getIn(['entities', props.entityType], _immutable2.default.Map()) || _immutable2.default.Map();
-};
-var getEntityOrder = exports.getEntityOrder = function getEntityOrder(state, props) {
-  return state.data.getIn(['entityOrder', props.entityType], _immutable2.default.List()) || _immutable2.default.List();
-};
-
-var getOrderedEntities = function getOrderedEntities(entityType, entityHash, entityOrder) {
-  return _defineProperty({}, (0, _pluralize2.default)(entityType), _immutable2.default.OrderedMap().withMutations(function (map) {
-    // eslint-disable-line new-cap
-    entityOrder.forEach(function (entityId, index) {
-      var entity = entityHash[(0, _pluralize2.default)(entityType)].get(entityId);
-
-      if (entity) {
-        map.set(index, entity);
-      }
-    });
-  }));
-};
-
-var selectEntity = exports.selectEntity = (0, _reselect.createSelector)([getId, getEntityType, getEntities], function (id, entityType, entities) {
-  return _defineProperty({}, entityType, entities.find(function (entity) {
-    return entity.getIn(['id'], '').toString() === id.toString();
-  }, null, _immutable2.default.Map()));
-});
-
-var selectEntities = exports.selectEntities = (0, _reselect.createSelector)([getEntityType, getEntities], function (entityType, entities) {
-  return _defineProperty({}, (0, _pluralize2.default)(entityType), entities);
-});
-
-var selectEntitiesWhere = exports.selectEntitiesWhere = (0, _reselect.createSelector)([getProps, getEntityType, getEntities], function (props, entityType, entities) {
-  var propsWithoutEntityType = Object.assign({}, props);
-  delete propsWithoutEntityType.entityType;
-
-  return _defineProperty({}, (0, _pluralize2.default)(entityType), entities.filter(function (entity) {
-    return Object.keys(propsWithoutEntityType).every(function (prop) {
-      var key = prop;
-      var value = props[prop] === 'id' ? props[prop].toString() : props[prop];
-
-      return entity.getIn([key], '') === value;
-    });
-  }, null, _immutable2.default.Map()));
-});
-
-var selectEntityOrder = exports.selectEntityOrder = (0, _reselect.createSelector)([getEntityOrder], function (entityOrder) {
-  return {
-    entityOrder: entityOrder
+var createGetPagination = function createGetPagination(entityType) {
+  return function (state) {
+    return state.data.getIn(['pagination', entityType], _immutable2.default.Map()) || _immutable2.default.Map();
   };
-});
-
-var selectOrderedEntities = exports.selectOrderedEntities = (0, _reselect.createSelector)([getEntityType, selectEntities, getEntityOrder], getOrderedEntities);
-
-var selectPagination = exports.selectPagination = (0, _reselect.createSelector)([getPagination], function (pagination) {
-  return {
-    pagination: pagination
+};
+var createGetEntities = function createGetEntities(entityType) {
+  return function (state) {
+    return state.data.getIn(['entities', entityType], _immutable2.default.Map()) || _immutable2.default.Map();
   };
-});
+};
+var createGetEntityOrder = function createGetEntityOrder(entityType) {
+  return function (state) {
+    return state.data.getIn(['entityOrder', entityType], _immutable2.default.List()) || _immutable2.default.List();
+  };
+};
+
+var createEntitySelector = exports.createEntitySelector = function createEntitySelector(entityType) {
+  var getEntities = createGetEntities(entityType);
+
+  return (0, _reselect.createSelector)([getId, getEntities], function (id, entities) {
+    return entities.find(function (entity) {
+      return entity.get('id', '').toString() === id.toString();
+    }, null, null);
+  });
+};
+
+var createEntitiesSelector = exports.createEntitiesSelector = function createEntitiesSelector(entityType) {
+  var getEntities = createGetEntities(entityType);
+
+  return (0, _reselect.createSelector)([getEntities], function (entities) {
+    return entities;
+  });
+};
+
+var createWhereSelector = exports.createWhereSelector = function createWhereSelector(entityType) {
+  var getEntities = createGetEntities(entityType);
+
+  return (0, _reselect.createSelector)([getProps, getEntities], function (props, entities) {
+    return entities.filter(function (entity) {
+      return Object.keys(props).every(function (prop) {
+        var key = prop;
+        var value = props[prop] === 'id' ? props[prop].toString() : props[prop];
+        var entityValue = entity.getIn([key], '');
+
+        if (Array.isArray(value)) {
+          return value.includes(entityValue);
+        }
+
+        return entityValue === value;
+      });
+    }, null, _immutable2.default.Map());
+  });
+};
+
+var createEntityOrderSelector = exports.createEntityOrderSelector = function createEntityOrderSelector(entityType) {
+  var getEntityOrder = createGetEntityOrder(entityType);
+  return (0, _reselect.createSelector)([getEntityOrder], function (entityOrder) {
+    return entityOrder;
+  });
+};
+
+var createOrderedEntitiesSelector = exports.createOrderedEntitiesSelector = function createOrderedEntitiesSelector(entityType, entitiesSelector) {
+  var getEntityOrder = createGetEntityOrder(entityType);
+
+  return (0, _reselect.createSelector)([entitiesSelector, getEntityOrder], function (entityHash, entityOrder) {
+    return _immutable2.default.OrderedMap().withMutations(function (map) {
+      // eslint-disable-line new-cap
+      entityOrder.forEach(function (entityId, index) {
+        var entity = entityHash.get(entityId);
+
+        if (entity) {
+          map.set(index, entity);
+        }
+      });
+    });
+  });
+};
+
+var createPaginationSelector = exports.createPaginationSelector = function createPaginationSelector(entityType) {
+  var getPagination = createGetPagination(entityType);
+
+  return (0, _reselect.createSelector)([getPagination], function (pagination) {
+    return pagination;
+  });
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -131,7 +131,8 @@
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-9">&#182;</a>
               </div>
-              <p>Build your Model on top of the ORM. The object definition is the exact same as Immutable Records (<a href="https://facebook.github.io/immutable-js/docs/#/Record)">https://facebook.github.io/immutable-js/docs/#/Record)</a>.</p>
+              <p>Build your Model on top of the ORM. The object definition is the exact same as Immutable Records (<a href="https://facebook.github.io/immutable-js/docs/#/Record">https://facebook.github.io/immutable-js/docs/#/Record</a>).
+The second parameter is the recordType and is used to look up your model in the Redux store.</p>
 
             </div>
             
@@ -139,7 +140,7 @@
   id: <span class="hljs-literal">null</span>,
   <span class="hljs-attr">myAttribute1</span>: <span class="hljs-literal">null</span>,
   <span class="hljs-attr">myAttribute2</span>: <span class="hljs-literal">null</span>
-}) {</pre></div></div>
+}, <span class="hljs-string">'myModel'</span>) {</pre></div></div>
             
         </li>
         
@@ -149,21 +150,6 @@
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-10">&#182;</a>
-              </div>
-              <p><code>static recordType()</code> <strong>is required</strong> and is used to look up your model in the Redux store.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">static</span> recordType() { <span class="hljs-keyword">return</span> <span class="hljs-string">'myModel'</span> };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-11">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-11">&#182;</a>
               </div>
               <p><code>valid()</code> allows you to define a custom validator for the model. Invalid models will
 not call the updateProps method.</p>
@@ -177,11 +163,11 @@ not call the updateProps method.</p>
         </li>
         
         
-        <li id="section-12">
+        <li id="section-11">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-12">&#182;</a>
+                <a class="pilcrow" href="#section-11">&#182;</a>
               </div>
               <p><code>onCreate(model, attributes, dispatch)</code> is called when using the <code>ORM.create()</code> method.
 This gets passed a copy of the immutable instance, the attributes the model was created with, and the store
@@ -196,11 +182,11 @@ dispatch function.</p>
         </li>
         
         
-        <li id="section-13">
+        <li id="section-12">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-13">&#182;</a>
+                <a class="pilcrow" href="#section-12">&#182;</a>
               </div>
               <p><code>onUpdate(model, attributes, dispatch)</code> is called when using the <code>ORM.updateProps()</code> method.
 This gets passed a copy of the immutable instance, the attributes the model was created with, and the store
@@ -215,11 +201,11 @@ dispatch function.</p>
         </li>
         
         
-        <li id="section-14">
+        <li id="section-13">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-14">&#182;</a>
+                <a class="pilcrow" href="#section-13">&#182;</a>
               </div>
               <p><code>onDestroy(model, dispatch)</code> is called when using the <code>ORM.updateProps()</code> method.
 This gets passed a copy of the immutable instance and the store dispatch function.</p>
@@ -234,14 +220,26 @@ This gets passed a copy of the immutable instance and the store dispatch functio
         </li>
         
         
+        <li id="section-14">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-14">&#182;</a>
+              </div>
+              <h2 id="usage-in-components">Usage in Components</h2>
+
+            </div>
+            
+        </li>
+        
+        
         <li id="section-15">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-15">&#182;</a>
               </div>
-              <h2 id="usage-in-components">Usage in Components</h2>
-
+              
             </div>
             
         </li>
@@ -253,18 +251,6 @@ This gets passed a copy of the immutable instance and the store dispatch functio
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-16">&#182;</a>
               </div>
-              
-            </div>
-            
-        </li>
-        
-        
-        <li id="section-17">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-17">&#182;</a>
-              </div>
               <p>Define your connected component as usual</p>
 
             </div>
@@ -275,11 +261,11 @@ This gets passed a copy of the immutable instance and the store dispatch functio
         </li>
         
         
-        <li id="section-18">
+        <li id="section-17">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-18">&#182;</a>
+                <a class="pilcrow" href="#section-17">&#182;</a>
               </div>
               <p>Using PropTypes isn’t required but is good practice. The <code>where</code> method returns an
 Immutable List of our Record Types.</p>
@@ -298,11 +284,11 @@ Immutable List of our Record Types.</p>
         </li>
         
         
-        <li id="section-19">
+        <li id="section-18">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-19">&#182;</a>
+                <a class="pilcrow" href="#section-18">&#182;</a>
               </div>
               <p>We have direct access to the model attributes here which makes them easy to print.
 With the addition of the onClick handler, our model will automatically update its value
@@ -319,11 +305,11 @@ as well as calling the <code>onUpdate</code> action to do any backend processing
         </li>
         
         
-        <li id="section-20">
+        <li id="section-19">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-20">&#182;</a>
+                <a class="pilcrow" href="#section-19">&#182;</a>
               </div>
               <p>We do the <code>where</code> call inside the connect mapStateToProps method so that it will receive
 updates when the Redux store changes and continue to pass them down the render tree.</p>
@@ -341,14 +327,26 @@ updates when the Redux store changes and continue to pass them down the render t
         </li>
         
         
+        <li id="section-20">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-20">&#182;</a>
+              </div>
+              <h2 id="the-api">The API</h2>
+
+            </div>
+            
+        </li>
+        
+        
         <li id="section-21">
             <div class="annotation">
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-21">&#182;</a>
               </div>
-              <h2 id="the-api">The API</h2>
-
+              
             </div>
             
         </li>
@@ -360,7 +358,8 @@ updates when the Redux store changes and continue to pass them down the render t
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-22">&#182;</a>
               </div>
-              
+              <p>Class Methods</p>
+
             </div>
             
         </li>
@@ -372,9 +371,11 @@ updates when the Redux store changes and continue to pass them down the render t
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-23">&#182;</a>
               </div>
-              <p>Class Methods</p>
+              <p>The <code>recordType</code> method returns the recordType specified in the model definition.</p>
 
             </div>
+            
+            <div class="content"><div class='highlight'><pre>MyModel.recordType();</pre></div></div>
             
         </li>
         
@@ -385,8 +386,7 @@ updates when the Redux store changes and continue to pass them down the render t
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-24">&#182;</a>
               </div>
-              <p>The <code>order</code> method returns the id order of the Models as received from the server.
-It’s returned as an array by default but can be returned as immutable by passing true to the method.</p>
+              <p>The <code>order</code> method returns an Immutable List of ids containing the order of the Models as received from the server.</p>
 
             </div>
             
@@ -416,8 +416,7 @@ It’s returned as an array by default but can be returned as immutable by passi
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-26">&#182;</a>
               </div>
-              <p>The <code>pagiantion</code> method returns a Javascript Object that contains the pagination information returned from the server.
-It can also be returned as an Immutable by passing true to the method.</p>
+              <p>The <code>pagiantion</code> method returns the pagination information returned from the server.</p>
 
             </div>
             

--- a/index.jsx
+++ b/index.jsx
@@ -17,14 +17,12 @@ ORM.Config.debug = true;
 // ----------------
 
 // Build your Model on top of the ORM. The object definition is the exact same as Immutable Records (https://facebook.github.io/immutable-js/docs/#/Record).
+// The second parameter is the recordType and is used to look up your model in the Redux store.
 class MyModel extends ORM.Base({
   id: null,
   myAttribute1: null,
   myAttribute2: null
-}) {
-  // `static recordType()` **is required** and is used to look up your model in the Redux store.
-  static recordType() { return 'myModel' };
-
+}, 'myModel') {
   // `valid()` allows you to define a custom validator for the model. Invalid models will
   // not call the updateProps method.
   valid() {
@@ -92,15 +90,16 @@ export default connect(mapStateToProps)(MyComponent);
 
 // Class Methods
 
-// The `order` method returns the id order of the Models as received from the server.
-// It's returned as an array by default but can be returned as immutable by passing true to the method.
+// The `recordType` method returns the recordType specified in the model definition.
+MyModel.recordType();
+
+// The `order` method returns an Immutable List of ids containing the order of the Models as received from the server.
 MyModel.order();
 
 // The `ordered` method returns an ordered Immutable List based upon the id order received from the server.
 MyModel.ordered();
 
-// The `pagiantion` method returns a Javascript Object that contains the pagination information returned from the server.
-// It can also be returned as an Immutable by passing true to the method.
+// The `pagiantion` method returns the pagination information returned from the server.
 MyModel.pagination();
 
 // The `findById` method returns a single instance of the Model Type with the data set if found or an empty version of the Model Type otherwise.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crorm",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "Catch&Release ORM",
   "main": "dist/orm.js",
   "scripts": {
@@ -29,7 +29,6 @@
   "private": false,
   "dependencies": {
     "immutable": "^3.8.2",
-    "pluralize": "^7.0.0",
     "reselect": "^3.0.1"
   },
   "devDependencies": {

--- a/test/createStore.js
+++ b/test/createStore.js
@@ -1,22 +1,23 @@
 import Immutable from 'immutable';
 import { createStore, combineReducers } from 'redux';
+import { Shot } from './models';
 
 // Setup Redux Store
 export const initialState = Immutable.fromJS({
   entities: {
     shot: {
-      1234: {
+      1234: new Shot({
         id: '1234',
         projectId: '1'
-      },
-      2345: {
+      }),
+      2345: new Shot({
         id: '2345',
         projectId: '1'
-      },
-      3456: {
+      }),
+      3456: new Shot({
         id: '3456',
         projectId: '2'
-      }
+      })
     }
   },
   entityOrder: {

--- a/test/models.js
+++ b/test/models.js
@@ -1,0 +1,28 @@
+import ORM from '../src/orm';
+
+export const onCreateSpy = jest.fn();
+export const onUpdateSpy = jest.fn();
+export const onDestroySpy = jest.fn();
+
+export class Shot extends ORM.Base({
+  id: null,
+  projectId: null
+}, 'shot') {
+  valid() {
+    return !!this.projectId;
+  }
+
+  onCreate(shot, attributes, dispatch) { // eslint-disable-line class-methods-use-this
+    onCreateSpy(shot, attributes);
+  }
+
+  onUpdate(shot, attributes, dispatch) { // eslint-disable-line class-methods-use-this
+    onUpdateSpy(shot, attributes);
+  }
+
+  onDestroy(shot, dispatch) { // eslint-disable-line class-methods-use-this
+    onDestroySpy(shot);
+  }
+}
+
+export class Project extends ORM.Base({ id: null }, 'project') {}

--- a/test/ormBase.test.js
+++ b/test/ormBase.test.js
@@ -1,64 +1,13 @@
 import Immutable from 'immutable';
-import { spyOn } from 'jest';
 
 import ORM from '../src/orm';
-import * as selectors from '../src/orm/ormSelectors';
 import { store } from './createStore';
-
+import { Shot, Project, onCreateSpy, onDestroySpy, onUpdateSpy } from './models';
 
 ORM.Config.database = store;
 ORM.Config.debug = false;
 
-const onCreateSpy = jest.fn();
-const onUpdateSpy = jest.fn();
-const onDestroySpy = jest.fn();
-
 const Base = ORM.Base({});
-
-class Shot extends ORM.Base({
-  id: null,
-  projectId: null
-}, 'shot') {
-  static recordType() { return 'shot'; }
-
-  valid() {
-    return !!this.projectId;
-  }
-
-  onCreate(shot, attributes, dispatch) { // eslint-disable-line class-methods-use-this
-    onCreateSpy(shot, attributes);
-  }
-
-  onUpdate(shot, attributes, dispatch) { // eslint-disable-line class-methods-use-this
-    onUpdateSpy(shot, attributes);
-  }
-
-  onDestroy(shot, dispatch) { // eslint-disable-line class-methods-use-this
-    onDestroySpy(shot);
-  }
-}
-
-class Project extends ORM.Base({
-  id: null
-}, 'project') {
-  static recordType() { return 'project'; }
-
-  valid() {
-    return !!this.projectId;
-  }
-
-  onCreate(project, attributes, dispatch) { // eslint-disable-line class-methods-use-this
-    onCreateSpy(project, attributes);
-  }
-
-  onUpdate(project, attributes, dispatch) { // eslint-disable-line class-methods-use-this
-    onUpdateSpy(project, attributes);
-  }
-
-  onDestroy(project, dispatch) { // eslint-disable-line class-methods-use-this
-    onDestroySpy(project);
-  }
-}
 
 describe('ORMBase', () => {
   const classMethods = ['order', 'ordered', 'pagination', 'findById', 'all', 'where', 'create'];
@@ -177,16 +126,8 @@ describe('ORMBase', () => {
       });
 
       describe('order', () => {
-        describe('array', () => {
-          test('returns the order array', () => {
-            expect(Shot.order()).toEqual(['2345', '3456', '1234']);
-          });
-        });
-
-        describe('immutable', () => {
-          test('returns the order immutable', () => {
-            expect(Shot.order(true)).toEqual({ entityOrder: Immutable.List(['2345', '3456', '1234']) });
-          });
+        test('returns the order immutable', () => {
+          expect(Shot.order(true)).toEqual(Immutable.List(['2345', '3456', '1234']));
         });
       });
 
@@ -196,7 +137,7 @@ describe('ORMBase', () => {
 
         describe('without filter', () => {
           beforeEach(() => {
-            order = Shot.order(true);
+            order = Shot.order();
             ordered = Shot.ordered();
           });
 
@@ -209,13 +150,13 @@ describe('ORMBase', () => {
           });
 
           test('returns ordered shots', () => {
-            expect(ordered.map(shot => shot.id)).toEqual(order.entityOrder);
+            expect(ordered.map(shot => shot.id)).toEqual(Immutable.List(['2345', '3456', '1234']));
           });
         });
 
         describe('with filter', () => {
           beforeEach(() => {
-            order = Shot.order(true);
+            order = Shot.order();
             ordered = Shot.ordered({ projectId: '1' });
           });
 
@@ -232,9 +173,36 @@ describe('ORMBase', () => {
 
           test('returns ordered shots', () => {
             const ids = ordered.map(shot => shot.id);
-            const includedEntities = order.entityOrder.filter((id) => ids.includes(id));
+            const includedEntities = order.filter((id) => ids.includes(id));
 
             expect(ids).toEqual(includedEntities);
+          });
+        });
+
+        describe('memoization', () => {
+          beforeEach(() => {
+            ordered = Shot.ordered();
+          });
+
+          describe('basic', () => {
+            test('returns the memoized result', () => {
+              expect(Shot.ordered()).toEqual(ordered);
+            });
+          });
+
+          describe('entity scoped', () => {
+            test('returns the memoized result', () => {
+              // calling all on a different entity should not invalidate the cache
+              Project.ordered();
+
+              expect(Shot.ordered()).toEqual(ordered);
+            });
+          });
+
+          describe('predicate changes', () => {
+            test('returns different result', () => {
+              expect(Shot.ordered({ predicate: '1' })).not.toEqual(ordered);
+            });
           });
         });
       });
@@ -246,31 +214,83 @@ describe('ORMBase', () => {
           pagination = Shot.pagination();
         });
 
-        test('returns an object', () => {
-          expect(pagination).toBeInstanceOf(Object);
+        describe('results', () => {
+          test('returns an object', () => {
+            expect(pagination).toBeInstanceOf(Object);
+          });
+
+          test('returns the Shot pagination', () => {
+            expect(pagination.toJS().current_page).toBe(1);
+          });
         });
 
-        test('returns the Shot pagination', () => {
-          expect(pagination.current_page).toBe(1);
+        describe('memoization', () => {
+          describe('basic', () => {
+            test('returns the memoized result', () => {
+              expect(Shot.pagination()).toEqual(pagination);
+            });
+          });
+
+          describe('entity scoped', () => {
+            test('returns the memoized result', () => {
+              Project.pagination();
+
+              expect(Shot.pagination()).toEqual(pagination);
+            });
+          });
         });
       });
 
       describe('find', () => {
-        describe('found', () => {
+        describe('results', () => {
+          describe('entity found', () => {
+            let shot;
+
+            beforeEach(() => {
+              shot = Shot.findById(1234);
+            });
+
+            test('returns a Shot instance', () => {
+              expect(shot).toBeInstanceOf(Shot);
+            });
+          });
+
+          describe('entity not found', () => {
+            test('returns null', () => {
+              expect(Shot.findById(9999)).toBeNull();
+            });
+          });
+        });
+
+        describe('memoization', () => {
           let shot;
 
           beforeEach(() => {
             shot = Shot.findById(1234);
           });
 
-          test('returns a Shot instance', () => {
-            expect(shot).toBeInstanceOf(Shot);
+          describe('basic', () => {
+            test('returns the memoized result', () => {
+              expect(Shot.findById(1234)).toEqual(shot);
+            });
           });
-        });
 
-        describe('not found', () => {
-          test('returns null', () => {
-            expect(Shot.findById(9999)).toBeInstanceOf(Shot);
+          describe('entity scoped', () => {
+            test('returns the memoized result', () => {
+              // calling the method on a different entity should not invalidate the cache
+              Project.findById(1234);
+
+              expect(Shot.findById(1234)).toEqual(shot);
+            });
+          });
+
+          describe('predicate changes', () => {
+            test('returns different result', () => {
+              const newShot = Shot.findById(2345);
+
+              expect(newShot).not.toEqual(shot);
+              expect(newShot).toBeInstanceOf(Shot);
+            });
           });
         });
       });
@@ -282,75 +302,117 @@ describe('ORMBase', () => {
           shots = Shot.all();
         });
 
-        test('returns an Immutable Map', () => {
-          expect(shots).toBeInstanceOf(Immutable.Map);
+        describe('results', () => {
+          test('returns an Immutable Map', () => {
+            expect(shots).toBeInstanceOf(Immutable.Map);
+          });
+
+          test('array items are Shots', () => {
+            expect(shots.first()).toBeInstanceOf(Shot);
+          });
+
+          test('returns all the shots, unordered', () => {
+            expect(shots.count()).toEqual(3);
+          });
         });
 
-        test('array items are Shots', () => {
-          expect(shots.first()).toBeInstanceOf(Shot);
-        });
+        describe('memoization', () => {
+          describe('basic', () => {
+            test('returns the memoized result', () => {
+              expect(Shot.all()).toEqual(shots);
+            });
+          });
 
-        test('returns all the shots, unordered', () => {
-          expect(shots.count()).toEqual(3);
+          describe('entity scoped', () => {
+            test('returns the memoized result', () => {
+              // calling the method on a different entity should not invalidate the cache
+              Project.all();
+
+              expect(Shot.all()).toEqual(shots);
+            });
+          });
         });
       });
 
       describe('where', () => {
+        let results;
+
         describe('results', () => {
-          let results;
+          describe('has results', () => {
+            describe('single match value', () => {
+              beforeEach(() => {
+                results = Shot.where({ projectId: '1' });
+              });
 
-          describe('single match value', () => {
-            beforeEach(() => {
-              results = Shot.where({ projectId: '1' });
+              test('returns an Immutable List', () => {
+                expect(results).toBeInstanceOf(Immutable.List);
+              });
+
+              test('array contains all results', () => {
+                expect(results.count()).toBe(2);
+                expect(results.every((result) => result.projectId === '1')).toBe(true);
+              });
+
+              test('array items are Shots', () => {
+                expect(results.first()).toBeInstanceOf(Shot);
+              });
             });
 
-            test('returns an Immutable List', () => {
-              expect(results).toBeInstanceOf(Immutable.List);
-            });
+            describe('array of matchable values', () => {
+              beforeEach(() => {
+                results = Shot.where({ projectId: ['1', '2'] });
+              });
 
-            test('array contains all results', () => {
-              expect(results.count()).toBe(2);
-              expect(results.every((result) => result.projectId === '1')).toBe(true);
-            });
+              test('returns an Immutable List', () => {
+                expect(results).toBeInstanceOf(Immutable.List);
+              });
 
-            test('array items are Shots', () => {
-              expect(results.first()).toBeInstanceOf(Shot);
+              test('array contains all results', () => {
+                expect(results.count()).toBe(3);
+                expect(results.every((result) => ['1', '2'].includes(result.projectId))).toBe(true);
+              });
+
+              test('array items are Shots', () => {
+                expect(results.first()).toBeInstanceOf(Shot);
+              });
             });
           });
 
-          describe('array of matchable values', () => {
+          describe('no results', () => {
             beforeEach(() => {
-              results = Shot.where({ projectId: ['1', '2'] });
+              results = Shot.where({ projectId: '3' });
             });
 
             test('returns an Immutable List', () => {
               expect(results).toBeInstanceOf(Immutable.List);
             });
 
-            test('array contains all results', () => {
-              expect(results.count()).toBe(3);
-              expect(results.every((result) => ['1', '2'].includes(result.projectId))).toBe(true);
-            });
-
-            test('array items are Shots', () => {
-              expect(results.first()).toBeInstanceOf(Shot);
+            test('array is empty', () => {
+              expect(results.count()).toBe(0);
             });
           });
         });
 
-        describe('no results', () => {
-          let results;
+        describe('memoization', () => {
+          const predicate = { projectId: '1' };
 
           beforeEach(() => {
-            results = Shot.where({ projectId: '3' });
+            results = Shot.where(predicate);
           });
 
-          test('returns an Immutable List', () => {
-            expect(results).toBeInstanceOf(Immutable.List);
+          describe('basic', () => {
+            test('returns the memoized result', () => {
+              expect(Shot.where(predicate)).toEqual(results);
+            });
           });
 
-          test('array is empty', () => {
-            expect(results.count()).toBe(0);
+          describe('entity scoped', () => {
+            test('returns the memoized result', () => {
+              // calling the method on a different entity should not invalidate the cache
+              Project.where(predicate);
+
+              expect(Shot.where(predicate)).toEqual(results);
+            });
           });
         });
       });


### PR DESCRIPTION
The ORM selectors did not take advantage of reselect memoization due
to how they were written. Fix all the selectors such that memoization
is scoped to the Entity type.

A few breaking changes:
- recordType is set in the model definition. e.g. new Shot({}, 'shot')
- Selectors no longer reinstantiate the entities and just fetch the
records from the store. It is up to the reducer to store the entities
as ORM records properly.
- pagination() and order() no longer accept any parameter and always
return an immutable object