### PR TITLE
Change onCreate/Update/Destroy api

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ To Add Debug Output: `ORM.Config.debug = true;`
 
 `destroy()` - Marks the current model as destroyed and returns a "destroyed" instance. Calls an onDestroy to be overridden to save on the backend and update the store.
 
-`onCreate(instance, createProps, dispatch)` - Override to define what happens on create.
+`onCreate(dispatch, createProps)` - Override to define what happens on create.
 
-`onUpdate(instance, updateProps, dispatch)` - Override to define what happens on update.
+`onUpdate(dispatch, updateProps)` - Override to define what happens on update.
 
-`onDestroy(instance, dispatch)` - Override to define what happens on destroy.
+`onDestroy(dispatch)` - Override to define what happens on destroy.
 
 ### Pushing a New Version
 

--- a/src/orm/ormBase.js
+++ b/src/orm/ormBase.js
@@ -65,12 +65,9 @@ export default function(recordProps, recordType) {
     }
 
     static create(attributes = {}) {
-      const model = new this(Object.assign({}, attributes));
-      const dispatch = ORMBase.dispatch();
+      const model = new this({ ...attributes });
 
-      model.onCreate(model, attributes, dispatch);
-
-      return model;
+      return model.onCreate(ORMBase.dispatch(), attributes);
     }
 
     valid() { // eslint-disable-line class-methods-use-this
@@ -79,24 +76,24 @@ export default function(recordProps, recordType) {
 
     updateProps(props = {}) {
       if (this.valid()) {
-        const updateProps = Object.assign({}, props);
-
-        return this.onUpdate(this, updateProps, ORMBase.dispatch());
+        return this.onUpdate(ORMBase.dispatch(), { ...props });
       }
 
       return Promise.reject(new RecordInvalidError('record invalid!'));
     }
 
     destroy() {
-      return this.onDestroy(this, ORMBase.dispatch());
+      return this.onDestroy(ORMBase.dispatch());
     }
 
     onCreate() {
-      return this;
+      return Promise.resolve(this);
     }
 
-    onUpdate(_record, props) {
-      return Promise.resolve(this.merge(props));
+    onUpdate(_dispatch, props) {
+      const updatedRecord = this.merge(props);
+
+      return Promise.resolve(updatedRecord);
     }
 
     onDestroy() {

--- a/test/models.js
+++ b/test/models.js
@@ -1,27 +1,13 @@
 import ORM from '../src/orm';
 
 export const onCreateSpy = jest.fn().mockReturnValue('finish create');
-export const onUpdateSpy = jest.fn().mockReturnValue('finish update');
-export const onDestroySpy = jest.fn().mockReturnValue('finish destroy');
 
 export class Shot extends ORM.Base({
   id: null,
   projectId: null
 }, 'shot') {
-  valid() {
-    return !!this.projectId;
-  }
-
-  onCreate(shot, attributes, dispatch) { // eslint-disable-line class-methods-use-this
-    return onCreateSpy(shot, attributes);
-  }
-
-  onUpdate(shot, attributes, dispatch) { // eslint-disable-line class-methods-use-this
-    return onUpdateSpy(shot, attributes);
-  }
-
-  onDestroy(shot, dispatch) { // eslint-disable-line class-methods-use-this
-    return onDestroySpy(shot);
+  onCreate(dispatch, attributes) { // eslint-disable-line class-methods-use-this
+    return onCreateSpy(dispatch, attributes);
   }
 }
 


### PR DESCRIPTION
Seems redundant to include 'this' in the arguments. So remove it from
all of them.
Update create method to returns the onCreate handler result. So it
matches update and destroy.