### PR TITLE
Add order key support and change the store order structure

### DIFF
--- a/dist/orm/ormBase.js
+++ b/dist/orm/ormBase.js
@@ -127,7 +127,8 @@ function _default(recordProps, _recordType) {
     }, {
       key: "order",
       value: function order() {
-        return selectEntityOrder(ORMBase.database());
+        var predicates = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : EMPTY_PREDICATE;
+        return selectEntityOrder(ORMBase.database(), predicates);
       }
     }, {
       key: "ordered",
@@ -138,7 +139,8 @@ function _default(recordProps, _recordType) {
     }, {
       key: "pagination",
       value: function pagination() {
-        return selectPagination(ORMBase.database());
+        var predicates = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : EMPTY_PREDICATE;
+        return selectPagination(ORMBase.database(), predicates);
       }
     }, {
       key: "findById",

--- a/dist/orm/ormSelectors.js
+++ b/dist/orm/ormSelectors.js
@@ -11,8 +11,15 @@ var _reselect = require("reselect");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var getProps = function getProps(state, props) {
-  return props;
+function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
+var getProps = function getProps(state, _ref) {
+  var key = _ref.key,
+      rest = _objectWithoutProperties(_ref, ["key"]);
+
+  return rest;
 };
 
 var getId = function getId(state, props) {
@@ -20,8 +27,8 @@ var getId = function getId(state, props) {
 };
 
 var createGetPagination = function createGetPagination(entityType) {
-  return function (state) {
-    return state.data.getIn(['pagination', entityType], _immutable.default.Map()) || _immutable.default.Map();
+  return function (state, props) {
+    return state.data.getIn(['pagination', entityType, props.key || entityType], _immutable.default.Map()) || _immutable.default.Map();
   };
 };
 
@@ -32,8 +39,8 @@ var createGetEntities = function createGetEntities(entityType) {
 };
 
 var createGetEntityOrder = function createGetEntityOrder(entityType) {
-  return function (state) {
-    return state.data.getIn(['entityOrder', entityType], _immutable.default.List()) || _immutable.default.List();
+  return function (state, props) {
+    return state.data.getIn(['entityOrder', entityType, props.key || entityType], _immutable.default.List()) || _immutable.default.List();
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/crorm",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Catch&Release ORM",
   "main": "dist/orm.js",
   "scripts": {

--- a/src/orm/ormBase.js
+++ b/src/orm/ormBase.js
@@ -40,16 +40,16 @@ export default function(recordProps, recordType) {
       return recordType;
     }
 
-    static order() {
-      return selectEntityOrder(ORMBase.database());
+    static order(predicates = EMPTY_PREDICATE) {
+      return selectEntityOrder(ORMBase.database(), predicates);
     }
 
     static ordered(predicates = EMPTY_PREDICATE) {
       return selectOrderedEntities(ORMBase.database(), predicates);
     }
 
-    static pagination() {
-      return selectPagination(ORMBase.database());
+    static pagination(predicates = EMPTY_PREDICATE) {
+      return selectPagination(ORMBase.database(), predicates);
     }
 
     static findById(id = '') {

--- a/src/orm/ormSelectors.js
+++ b/src/orm/ormSelectors.js
@@ -1,11 +1,11 @@
 import Immutable from 'immutable';
 import { createSelector } from 'reselect';
 
-const getProps = (state, props) => props;
+const getProps = (state, { key, ...rest }) => rest;
 const getId = (state, props) => props.id;
-const createGetPagination = (entityType) => (state) => (state.data.getIn(['pagination', entityType], Immutable.Map()) || Immutable.Map());
+const createGetPagination = (entityType) => (state, props) => (state.data.getIn(['pagination', entityType, props.key || entityType], Immutable.Map()) || Immutable.Map());
 const createGetEntities = (entityType) => (state) => (state.data.getIn(['entities', entityType], Immutable.Map()) || Immutable.Map());
-const createGetEntityOrder = (entityType) => (state) => (state.data.getIn(['entityOrder', entityType], Immutable.List()) || Immutable.List());
+const createGetEntityOrder = (entityType) => (state, props) => (state.data.getIn(['entityOrder', entityType, props.key || entityType], Immutable.List()) || Immutable.List());
 
 export const createEntitySelector = (entityType) => {
   const getEntities = createGetEntities(entityType);

--- a/test/createStore.js
+++ b/test/createStore.js
@@ -21,16 +21,29 @@ export const initialState = Immutable.fromJS({
     }
   },
   entityOrder: {
-    shot: ['2345', '3456', '1234']
+    shot: {
+      shot: ['2345', '3456'],
+      collection_shot: ['3456', '1234']
+    }
   },
   pagination: {
     shot: {
-      previous_page: null,
-      next_page: 2,
-      current_page: 1,
-      total_pages: 3,
-      total_count: 111,
-      count: 50
+      shot: {
+        previous_page: null,
+        next_page: 2,
+        current_page: 1,
+        total_pages: 3,
+        total_count: 111,
+        count: 50
+      },
+      collection_shot: {
+        previous_page: null,
+        next_page: 2,
+        current_page: 1,
+        total_pages: 5,
+        total_count: 10,
+        count: 2
+      }
     }
   }
 });

--- a/test/ormBase.test.js
+++ b/test/ormBase.test.js
@@ -240,18 +240,24 @@ describe('ORMBase', () => {
       });
 
       describe('order', () => {
-        test('returns the order immutable', () => {
-          expect(Shot.order(true)).toEqual(Immutable.List(['2345', '3456', '1234']));
+        describe('default order key', () => {
+          test('returns the order immutable', () => {
+            expect(Shot.order()).toEqual(Immutable.List(['2345', '3456']));
+          });
+        });
+
+        describe('custom order key', () => {
+          test('returns the order immutable', () => {
+            expect(Shot.order({ key: 'collection_shot' })).toEqual(Immutable.List(['3456', '1234']));
+          });
         });
       });
 
       describe('ordered', () => {
-        let order;
         let ordered;
 
-        describe('without filter', () => {
+        describe('default behavior', () => {
           beforeEach(() => {
-            order = Shot.order();
             ordered = Shot.ordered();
           });
 
@@ -264,11 +270,31 @@ describe('ORMBase', () => {
           });
 
           test('returns ordered shots', () => {
-            expect(ordered.map(shot => shot.id)).toEqual(Immutable.List(['2345', '3456', '1234']));
+            expect(ordered.map(shot => shot.id)).toEqual(Immutable.List(['2345', '3456']));
+          });
+        });
+
+        describe('with order key', () => {
+          beforeEach(() => {
+            ordered = Shot.ordered({ key: 'collection_shot' });
+          });
+
+          test('returns an Immutable List', () => {
+            expect(ordered).toBeInstanceOf(Immutable.List);
+          });
+
+          test('returns Shot instances', () => {
+            expect(ordered.first()).toBeInstanceOf(Shot);
+          });
+
+          test('returns ordered shots', () => {
+            expect(ordered.map(shot => shot.id)).toEqual(Immutable.List(['3456', '1234']));
           });
         });
 
         describe('with filter', () => {
+          let order;
+
           beforeEach(() => {
             order = Shot.order();
             ordered = Shot.ordered({ projectId: '1' });
@@ -324,21 +350,45 @@ describe('ORMBase', () => {
       describe('pagination', () => {
         let pagination;
 
-        beforeEach(() => {
-          pagination = Shot.pagination();
-        });
-
-        describe('results', () => {
-          test('returns an object', () => {
-            expect(pagination).toBeInstanceOf(Object);
+        describe('default behavior', () => {
+          beforeEach(() => {
+            pagination = Shot.pagination();
           });
 
-          test('returns the Shot pagination', () => {
-            expect(pagination.toJS().current_page).toBe(1);
+          test('returns the pagination', () => {
+            expect(pagination).toEqual(Immutable.fromJS({
+              previous_page: null,
+              next_page: 2,
+              current_page: 1,
+              total_pages: 3,
+              total_count: 111,
+              count: 50
+            }));
+          });
+        });
+
+        describe('with order key', () => {
+          beforeEach(() => {
+            pagination = Shot.pagination({ key: 'collection_shot' });
+          });
+
+          test('returns the pagination', () => {
+            expect(pagination).toEqual(Immutable.fromJS({
+              previous_page: null,
+              next_page: 2,
+              current_page: 1,
+              total_pages: 5,
+              total_count: 10,
+              count: 2
+            }));
           });
         });
 
         describe('memoization', () => {
+          beforeEach(() => {
+            pagination = Shot.pagination();
+          });
+
           describe('basic', () => {
             test('returns the memoized result', () => {
               expect(Shot.pagination()).toBe(pagination);


### PR DESCRIPTION
This is a breaking change for anything that uses ordered, order or pagination.
The redux store now needs to structure the pagination/order data such that they are nested under entity types.

With this change, `Shot.ordered({ key: collection_shot })` will now return all the shots with the order under 
```
{
  entityOrder: {
    shot: {
       collection_shot: [2, 3]
    }
  }
}