### PR TITLE
Support additional arguments in create

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To Add Debug Output: `ORM.Config.debug = true;`
 
 `where(props = {})` - Get the instances where all props are matching.
 
-`create(props = {})` - Create an instance with the passed in props. Call an onCreate method to be overridden for server save and state update.
+`create(props = {})` - Create an instance with the passed in props. Call an onCreate method to be overridden for server save and state update. Any additional arguments passed to create will be passed down to onCreate.
 
 ##### Instance Methods
 

--- a/dist/orm/ormBase.js
+++ b/dist/orm/ormBase.js
@@ -165,7 +165,12 @@ function _default(recordProps, _recordType) {
       value: function create() {
         var attributes = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
         var model = new this(_objectSpread({}, attributes));
-        return model.onCreate(ORMBase.dispatch(), attributes);
+
+        for (var _len = arguments.length, rest = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+          rest[_key - 1] = arguments[_key];
+        }
+
+        return model.onCreate.apply(model, [ORMBase.dispatch(), attributes].concat(rest));
       }
     }]);
 

--- a/src/orm/ormBase.js
+++ b/src/orm/ormBase.js
@@ -64,10 +64,10 @@ export default function(recordProps, recordType) {
       return selectEntitiesWhere(ORMBase.database(), predicates);
     }
 
-    static create(attributes = {}) {
+    static create(attributes = {}, ...rest) {
       const model = new this({ ...attributes });
 
-      return model.onCreate(ORMBase.dispatch(), attributes);
+      return model.onCreate(ORMBase.dispatch(), attributes, ...rest);
     }
 
     valid() { // eslint-disable-line class-methods-use-this

--- a/test/models.js
+++ b/test/models.js
@@ -6,8 +6,8 @@ export class Shot extends ORM.Base({
   id: null,
   projectId: null
 }, 'shot') {
-  onCreate(dispatch, attributes) { // eslint-disable-line class-methods-use-this
-    return onCreateSpy(dispatch, attributes);
+  onCreate(...args) { // eslint-disable-line class-methods-use-this
+    return onCreateSpy(...args);
   }
 }
 

--- a/test/ormBase.test.js
+++ b/test/ormBase.test.js
@@ -599,6 +599,13 @@ describe('ORMBase', () => {
             expect(onCreateSpy).toHaveBeenCalledTimes(1);
             expect(onCreateSpy).toHaveBeenCalledWith(Base.dispatch(), attributes);
           });
+
+          test('passes any additional arguments alon to onCreate', () => {
+            const reducerParams = { orderKey: 'myKey' };
+            Shot.create(attributes, reducerParams);
+
+            expect(onCreateSpy).toHaveBeenCalledWith(Base.dispatch(), attributes, reducerParams);
+          });
         });
 
         describe('without attributes', () => {


### PR DESCRIPTION
[#165750303]

Example use is to pass down reducerParams for specifying order keys.